### PR TITLE
Fix isdigit for not str object passed on initialization

### DIFF
--- a/lib/routing.py
+++ b/lib/routing.py
@@ -48,7 +48,7 @@ class Plugin(object):
 
     def __init__(self, base_url=None):
         self._rules = {}  # function to list of rules
-        self.handle = int(sys.argv[1]) if sys.argv[1].isdigit() else -1
+        self.handle = int(sys.argv[1]) if str(sys.argv[1]).isdigit() else -1
         self.args = {}
         self.base_url = base_url
         if self.base_url is None:


### PR DESCRIPTION
Hi, using some plugins that depend on this one, I noted that in some case the argument is parsed naturally as an int and not as a string: so the isdigit method throws an error because it is not a valid member of int objects.

Trying to force the cast to string and apply isdigit after casting it results as a good way to fix this kind of bugs.

Please get a look on this pull request and eventually merge.

Bye 
Aleskandro