### PR TITLE
Strip trailing slashes

### DIFF
--- a/lib/routing.py
+++ b/lib/routing.py
@@ -150,6 +150,10 @@ class UrlRule:
         Check if path matches this rule. Returns a dictionary of the extracted
         arguments if match, otherwise None.
         """
+        # Strip trailing slashes
+        if len(path) > 1:
+            path = path.rstrip('/')
+
         # match = self._regex.search(urlsplit(path).path)
         match = self._regex.search(path)
         return match.groupdict() if match else None

--- a/lib/tests.py
+++ b/lib/tests.py
@@ -103,3 +103,12 @@ def test_arg_parsing(plugin):
     plugin.route("/foo")(f)
     plugin.run(['plugin://py.test/foo', '0', '?bar=baz'])
     assert plugin.args['bar'][0] == 'baz'
+
+
+def test_trailing_slashes():
+    assert UrlRule("/p/<foo>").match("/p/bar") == {'foo': 'bar'}
+    assert UrlRule("/p/<foo>").match("/p/bar/") == {'foo': 'bar'}
+    assert UrlRule("/p/<foo>").match("/p/bar//") == {'foo': 'bar'}
+    assert UrlRule("/p/<foo>").match("/p/bar///") == {'foo': 'bar'}
+
+

--- a/lib/tests.py
+++ b/lib/tests.py
@@ -110,5 +110,3 @@ def test_trailing_slashes():
     assert UrlRule("/p/<foo>").match("/p/bar/") == {'foo': 'bar'}
     assert UrlRule("/p/<foo>").match("/p/bar//") == {'foo': 'bar'}
     assert UrlRule("/p/<foo>").match("/p/bar///") == {'foo': 'bar'}
-
-


### PR DESCRIPTION
Because of a bug in `ActivateWindow()`, but also because it is more
forgiving, we strip trailing slashes before matching a path to a route.

This fixes #12 and relates to pietje666/plugin.video.vrt.nu#447