### PR TITLE
Fix an issue where sys.argv[1] does not exist

### DIFF
--- a/lib/routing.py
+++ b/lib/routing.py
@@ -56,7 +56,10 @@ class Plugin:
 
     def __init__(self, base_url=None):
         self._rules = {}  # function to list of rules
-        self.handle = int(sys.argv[1]) if sys.argv[1].isdigit() else -1
+        if len(sys.argv) > 1 and sys.argv[1].isdigit():
+            self.handle = int(sys.argv[1]) 
+        else:
+            self.handle = -1
         self.args = {}
         self.base_url = base_url
         if self.base_url is None:

--- a/lib/routing.py
+++ b/lib/routing.py
@@ -57,7 +57,7 @@ class Plugin:
     def __init__(self, base_url=None):
         self._rules = {}  # function to list of rules
         if len(sys.argv) > 1 and sys.argv[1].isdigit():
-            self.handle = int(sys.argv[1]) 
+            self.handle = int(sys.argv[1])
         else:
             self.handle = -1
         self.args = {}


### PR DESCRIPTION
We encountered this issue (in emilsvennesson/script.module.inputstreamhelper#91) and this fixes it.