### PR TITLE
Expose current path from Plugin() instance

### DIFF
--- a/lib/routing.py
+++ b/lib/routing.py
@@ -50,12 +50,19 @@ class Plugin:
     :ivar handle: The plugin handle from kodi
     :type handle: int
 
+    :ivar path: The current path
+    :type path: byte string
+
     :ivar args: The parsed query string.
     :type args: dict of byte strings
     """
 
     def __init__(self, base_url=None):
         self._rules = {}  # function to list of rules
+        if sys.argv:
+            self.path = urlsplit(sys.argv[0]).path or '/'
+        else:
+            self.path = '/'
         if len(sys.argv) > 1 and sys.argv[1].isdigit():
             self.handle = int(sys.argv[1])
         else:
@@ -116,10 +123,10 @@ class Plugin:
     def run(self, argv=None):
         if argv is None:
             argv = sys.argv
+        self.path = urlsplit(argv[0]).path or '/'
         if len(argv) > 2:
             self.args = parse_qs(argv[2].lstrip('?'))
-        path = urlsplit(argv[0]).path or '/'
-        self._dispatch(path)
+        self._dispatch(self.path)
 
     def redirect(self, path):
         self._dispatch(path)

--- a/lib/tests.py
+++ b/lib/tests.py
@@ -86,6 +86,16 @@ def test_dispatch(plugin):
     f.assert_called_with()
 
 
+def test_path(plugin):
+    f = mock.create_autospec(lambda: None)
+    plugin.route("/foo")(f)
+    plugin.run(['plugin://py.test/foo', '0'])
+    assert plugin.path == '/foo'
+    plugin.route("/foo/bar/baz")(f)
+    plugin.run(['plugin://py.test/foo/bar/baz', '0'])
+    assert plugin.path == '/foo/bar/baz'
+
+
 def test_no_route(plugin):
     f = lambda a: None
     plugin.route("/foo/<a>/<b>")(f)


### PR DESCRIPTION
So it has proven to be very useful if you can ask the plugin instance
what the currently used path is. This is cleaner than having to use
sys.argv (and performing the same manipulations).