### PR TITLE
Add a python setuptools setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 *.pyo
 .pytest_cache/
 .tox/
+
+build/
+dist/
+routing.egg-info/
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import os.path
+from xml.dom.minidom import parse
+from setuptools import setup
+
+project_dir = os.path.dirname(os.path.abspath(__file__))
+metadata = parse(os.path.join(project_dir, 'addon.xml'))
+addon_version = metadata.firstChild.getAttribute('version')
+
+setup(
+    name='routing',
+    version=addon_version,
+    url='https://github.com/tamland/kodi-plugin-routing',
+    author='tamland',
+    description='A routing module for kodi plugins',
+    long_description=open(os.path.join(project_dir, 'README.md')).read(),
+    keywords='Kodi, plugin, routing',
+    license='GPL-3.0',
+    package_dir={'': 'lib'},
+    py_modules=['routing'],
+    zip_safe=False,
+)


### PR DESCRIPTION
This is very convenient for pulling in the module for automated testing.
Before this we have to include the module in our project, but using this
we can actually pull it directly from Github using:

**requirements.txt**
```
git+git://github.com/tamland/kodi-plugin-routing.git@master#egg=routing
```

This can be tested by adding this to requirements.txt:
```
git+git://github.com/dagwieers/kodi-plugin-routing.git@setup#egg=routing
```

And then run

```
$ sudo pip install -r requirements.txt
Collecting routing from git+git://github.com/dagwieers/kodi-plugin-routing.git@setup#egg=routing (from -r requirements.txt (line 7))
  Cloning git://github.com/dagwieers/kodi-plugin-routing.git (to setup) to /tmp/pip-build-OMyYfj/routing
Installing collected packages: routing
  Running setup.py install for routing ... done
```