### PR TITLE
Assorted fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: python
 
 python:
 - '2.7'
+- '3.5'
 - '3.6'
 - '3.7'
+- '3.8'
 
 sudo: false
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
-ENVS := flake8,py27,py36
 export PYTHONPATH := $(CURDIR)/lib
-addon_xml := addon.xml
+PYTHON := python
 
-# Collect information to build as sensible package name
-name = $(shell xmllint --xpath 'string(/addon/@id)' $(addon_xml))
-version = $(shell xmllint --xpath 'string(/addon/@version)' $(addon_xml))
+name = $(shell xmllint --xpath 'string(/addon/@id)' addon.xml)
+version = $(shell xmllint --xpath 'string(/addon/@version)' addon.xml)
 git_branch = $(shell git rev-parse --abbrev-ref HEAD)
 git_hash = $(shell git rev-parse --short HEAD)
 
@@ -24,17 +22,17 @@ all: test
 
 package: zip
 
-test: sanity unit addon
+test: sanity unit
 
 sanity: pylint
 
 tox:
 	@echo -e "$(white)=$(blue) Starting sanity tox test$(reset)"
-	tox -q -e $(ENVS)
+	$(PYTHON) -m tox -q
 
 pylint:
 	@echo -e "$(white)=$(blue) Starting sanity pylint test$(reset)"
-	pylint lib/*.py
+	$(PYTHON) -m pylint lib/*.py
 
 addon: clean
 	@echo -e "$(white)=$(blue) Starting sanity addon tests$(reset)"
@@ -43,7 +41,7 @@ addon: clean
 
 unit:
 	@echo -e "$(white)=$(blue) Starting unit tests$(reset)"
-	pytest lib/tests.py
+	$(PYTHON) -m pytest lib/tests.py
 
 # NOTE: To make this work you need to clone to $name-$version
 zip: clean
@@ -53,6 +51,6 @@ zip: clean
 	@echo -e "$(white)=$(blue) Successfully wrote package as: $(white)../$(zip_name)$(reset)"
 
 clean:
-	find lib/ -name '*.pyc' -type f -delete
+	find lib/ -name '*.py[cod]' -type f -delete
 	find lib/ -name '__pycache__' -type d -delete
 	rm -rf .pytest_cache/ .tox/ *.log

--- a/lib/routing.py
+++ b/lib/routing.py
@@ -1,44 +1,30 @@
 # -*- coding: utf-8 -*-
-#
-# Copyright (C) 2014-2015 Thomas Amland
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright: (c) 2014-2015, Thomas Amland
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
 import sys
-try:
-    from urlparse import urlsplit, parse_qs
-except ImportError:
-    from urllib.parse import urlsplit, parse_qs
-try:
+try:  # Python 3
+    from urllib.parse import parse_qs, urlencode, urlsplit
+except ImportError:  # Python 2
     from urllib import urlencode
-except ImportError:
-    from urllib.parse import urlencode
+    from urlparse import parse_qs, urlsplit
 
 try:
-    import xbmc
-    import xbmcaddon
-    _addon_id = xbmcaddon.Addon().getAddonInfo('id')
+    from xbmc import LOGDEBUG, xlog
+    from xbmcaddon import Addon
+    ADDON_ID = Addon().getAddonInfo('id')
 
     def log(msg):
-        msg = "[%s][routing] %s" % (_addon_id, msg)
-        xbmc.log(msg, level=xbmc.LOGDEBUG)
+        msg = '[%s][routing] %s' % (ADDON_ID, msg)
+        xlog(msg, level=LOGDEBUG)
 except ImportError:
+    ADDON_ID = 'plugin.foo.bar'
     def log(msg):
-        print(msg)
+        print('[routing] %s' % msg)
 
 
 class RoutingError(Exception):
@@ -69,8 +55,9 @@ class Plugin:
             self.handle = -1
         self.args = {}
         self.base_url = base_url
+        self.addon_id = ADDON_ID
         if self.base_url is None:
-            self.base_url = "plugin://" + xbmcaddon.Addon().getAddonInfo('id')
+            self.base_url = 'plugin://{0}'.format(ADDON_ID)
 
     def route_for(self, path):
         """

--- a/lib/tests.py
+++ b/lib/tests.py
@@ -1,19 +1,7 @@
 # -*- coding: utf-8 -*-
-#
-# Copyright (C) 2015 Thomas Amland
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright: (c) 2014-2015, Thomas Amland
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+envlist = py27,py35,py36,py37,py38,flake8
+skipsdist = True
+skip_missing_interpreters = True
+
+[testenv:flake8]
+commands =
+    - {envbindir}/flake8
+deps =
+    flake8
+    flake8-coding
+    flake8-future-import
+
+[flake8]
+builtins = func
+max-line-length = 160
+ignore = E129,FI13,FI50,FI51,FI53,FI54,W503
+require-code = True
+min-version = 2.7
+exclude = .git,.tox,experiment
+
+[pytest]
+filterwarnings = default
+
+[pycodestyle]
+max-line-length = 160


### PR DESCRIPTION
This PR includes:
- Use a oneline GPLv3 license statement
- Favor Python 3 code over Python 2
- Expose addon_id to add-ons
- Avoid a second addon_id lookup
- Add PYTHON to Makefile to facilitate testing multiple python versions
- Add tox.ini configuration
- Test against python 3.5 and python 3.8
- Use selective imports